### PR TITLE
Infra/web app cors

### DIFF
--- a/apps/api-server/Api/Program.cs
+++ b/apps/api-server/Api/Program.cs
@@ -78,11 +78,13 @@ var app = builder.Build();
 
 app.UseAuthentication();
 app.UseAuthorization();
-app.UseCors(MyAllowSpecificOrigins);
 
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())
 {
+    // CORS in the deployment scenario of the solution 
+    // can be handled either on the Container Apps layer or the API Management layer
+    app.UseCors(MyAllowSpecificOrigins);
     app.MapOpenApi();
 }
 

--- a/apps/web-app/staticwebapp.config.json
+++ b/apps/web-app/staticwebapp.config.json
@@ -1,0 +1,5 @@
+{
+  "navigationFallback": {
+    "rewrite": "/index.html"
+  }
+}

--- a/infra/azure/github-bootstrap/variables.tf
+++ b/infra/azure/github-bootstrap/variables.tf
@@ -93,7 +93,7 @@ variable "environments" {
     dev = {
       display_order = 1
       display_name  = "Development"
-      redirect_urls = ["https://kind-meadow-08270b403-staging.1.azurestaticapps.net/", "https://kind-meadow-08270b403.1.azurestaticapps.net/"]
+      redirect_urls = ["https://gentle-desert-004159c03-staging.1.azurestaticapps.net/", "https://gentle-desert-004159c03.1.azurestaticapps.net/"]
     }
     # test = {
     #   display_order         = 2

--- a/infra/azure/readme.md
+++ b/infra/azure/readme.md
@@ -1,0 +1,9 @@
+Containing two terraform folders. More deailed readmes with instructions how to set everything up can be found in them.
+
+## github-bootstrap
+Sets up the CI/CD for Github and Entra related resources.
+
+## resources
+The actual resources needed to run the solution. Should be deployed with the CI/CD pipeline created by the bootstrap deployment.
+
+It contains logic to create resources in one environment. This environment is specified by the github workflow file that starts the terraform plan/apply/destroy.

--- a/infra/azure/resources/api_management/main.tf
+++ b/infra/azure/resources/api_management/main.tf
@@ -57,6 +57,10 @@ locals {
   client_app_ids = join("", [
     for client_id in var.container_app_client_ids : "<application-id>${client_id}</application-id>"
   ])
+
+  allowed_origins = join("", [
+    for url in var.cors_allowed_origins : "<origin>${url}</origin>"
+  ])
 }
 
 resource "azurerm_api_management_api_policy" "api_policy" {
@@ -83,6 +87,26 @@ resource "azurerm_api_management_api_policy" "api_policy" {
                 <!-- if there are multiple possible audiences, then add additional audience elements -->
             </audiences>
         </validate-azure-ad-token>
+        <cors allow-credentials="false">
+            <allowed-origins>
+                ${local.allowed_origins}
+            </allowed-origins>
+            <allowed-methods>
+                <method>GET</method>
+                <method>POST</method>
+                <method>PUT</method>
+                <method>DELETE</method>
+                <method>HEAD</method>
+                <method>OPTIONS</method>
+                <method>PATCH</method>
+            </allowed-methods>
+            <allowed-headers>
+                <header>Authorization</header>
+            </allowed-headers>
+            <expose-headers>
+                <header>Access-Control-Allow-Origin</header>
+            </expose-headers>
+        </cors>
     </inbound>
     <!-- Control if and how the requests are forwarded to services  -->
     <backend>

--- a/infra/azure/resources/api_management/variables.tf
+++ b/infra/azure/resources/api_management/variables.tf
@@ -18,6 +18,11 @@ variable "container_app_client_ids" {
   type        = list(string)
 }
 
+variable "cors_allowed_origins" {
+  description = "The URLs of the web sites that can access the API."
+  type        = list(string)
+}
+
 variable "publisher_name" {
   description = "The name of the API publisher."
   type        = string

--- a/infra/azure/resources/main.tf
+++ b/infra/azure/resources/main.tf
@@ -63,6 +63,7 @@ module "api_management" {
   api_path                 = "bingo"
   container_app_client_id  = var.service_client_id
   container_app_client_ids = [var.ui_client_id, var.test_client_id]
+  cors_allowed_origins     = [module.static_web_app.prod_url, module.static_web_app.staging_url]
 }
 
 data "github_repository" "repo" {

--- a/infra/azure/resources/readme.md
+++ b/infra/azure/resources/readme.md
@@ -21,7 +21,7 @@ So to make the API work, the flow is the following:
 - Open the Container App in the Azure Portal and enable the Service Container for the CosmosDB MongoDB resource, so that the running app can get the CosmosDB connection string using managed identity (this manual step is required because Terraform doesn't yet support it, as Service Connector for Container Apps is in preview)
 
 # Choices made
-### No secrets.
+### No secrets
 
 Most of these resources support Azure Managed Identity, and we rely on that to prompt the necessary rights to the resources to perform certain actions rather than usernames and passwords (for example the container app is granted the pull right needed to access an image from the container registry). An exception is Cosmos DB's MongoDB access, where a [Service Connector](https://learn.microsoft.com/en-us/azure/service-connector/how-to-integrate-cosmos-db?tabs=dotnet) is used to access the connection string (that includes the user name and password, so there's no need to store the password in a Key Vault etc. instead managed identity is used to allow the Container App to retrieve the connection string.)
 
@@ -35,3 +35,29 @@ It uses service principal to log in to Azure, while I'm relying on Managed Ident
 
 ### Not using [container-apps-deploy-action](https://github.com/Azure/container-apps-deploy-action)
 It is a deploy and/or create resource solution, and I want to keep my resource creations up to Terraform. In an ideal scenario deployment would be handled by a managed identity that can't create resources, but for now I'm using the same managed identity for deployment as the one that does terraform apply. Living with this solution it feels safer to use `az containerapp update` which won't create new resources in case I make a mistake referencing a named resource etc.
+
+### Authentication, API Management middleman and public network access
+The Container App instance can scale to 0, and I'd like to keep it scaled to 0 most of the time unless a legit user is calling it from the browser. If bots or unauthorized users try to call it, the app could be constantly awake doing nothing else but authenticating the requests and refusing them. The built-in authentication Azure provides for Container Apps [runs a sidecar in a replica](https://learn.microsoft.com/en-us/azure/container-apps/authentication#feature-architecture) which to my understanding still means that the app would keep it running just do deal with these requests.
+
+Here comes API Management into the picture with its [validate-azure-ad-token](https://learn.microsoft.com/en-us/azure/api-management/validate-azure-ad-token-policy) policy. As a middleman between the clients and the Container App, it rejects unauthorized requests almost free of charge, and so the Container App can only ever be awaken with requests that passed the token validation.
+
+Ideally with this setup the Container App would not be accessible publicly, but currently even the cheapest APIM tier that has virtual network support is too expensive for a project like this. That means that the container app's URL has to be treated like a secret despite it being accessible from the public internet.
+
+A drawback of this setup is that the APIM policy can only return generic 401 responses, so it won't help you figuring out why your token is invalid. Also, if you don't need other functionalities of APIM, and running at least one replica of the Container App constantly is not a concern for you, you can ditch this middle layer.
+
+Additionally, the server also validates the token. A big reason for this is that the APIM layer doesn't handle Authorization (checking if you have the right roles etc.), and also to keep the API access consistent between local development and the deployed version.
+
+### CORS
+Because the user interface and the API is deployed on two different hosts, the server needs to be set up to allow cross origin requests, otherwise the browser will reject the requests.
+
+There are 3 places where CORS can be set up, 1. the server itself, 2. the API Management and the 3. Container App resource. Because all requests are going through the APIM layer, I found out that CORS doesn't need to be configured on the Container App layer or the server itself, so CORS is configured with the [cors-policy](https://learn.microsoft.com/en-us/azure/api-management/cors-policy).
+
+
+# Other
+## Notes on the Static Web App deployment
+repository_url, repository_branch and repository_token are marked as non-required on the terraform documentation for azurerm_static_web_app, however I didn't have success deploying the app without them. Also, setting these up once the resource was created did nothing, so I had to recreate the resource with these provided. Creating the web app like this puts an automatically generated workflow file into your .github folder. As far as I understand, you are free to modify it (you even have to, for example in the case of Angular to tell it the app_location and output_location), but you shouldn't rename it.
+
+[As noted](https://learn.microsoft.com/en-gb/azure/static-web-apps/get-started-portal?tabs=vanilla-javascript&pivots=github#create-a-static-web-app), you might have to authorize Azure Static Web Apps in Github (Settings > Applications > Authorized OAuth Apps) so it can create the yaml file.
+
+## The use of a PAT in terraform
+Terraform can handle Github environment/repository variables and secrets to store information about the created resources (like the URLs of the API or Web App, because this solution is not utilizing a custom domain). For simplicity, a PAT is passed to terraform, which wouldn't be the right choice for an actual application. Long term it would be better to migrate to GitHub Apps to provide terraform short-lived access tokens.

--- a/readme.md
+++ b/readme.md
@@ -11,10 +11,10 @@ To develop locally you have to install the following:
 - .NET 9.0
 - mongosh >2.5.1
 - Docker
-- nodeJS 22
+- A [compatible node version](https://angular.dev/reference/versions) with Angular 20. The web app's package.json references a specific node engine because that's how you can tell the Azure Static Web App deployment [to use an appropriate one](https://learn.microsoft.com/en-us/azure/static-web-apps/build-configuration?tabs=identity&pivots=github-actions#custom-build-commands).
 
 Starting the API
-- use the [docker-compose.yml file](api-server/docker-compose.yml) to build and start the DB and the API from the root folder
+- use the [docker-compose.yml file](api-server/Api/docker-compose.yml) to build and start the DB and the API from the root folder
 
 Starting the UI
 - TODO


### PR DESCRIPTION
The API doesn't have to use cors when deployed.

Added staticwebapp.config.json so the web app would serve index.html despite the route opened.

Configured the CORS policy on the Api Management resource.

readme updates