### PR TITLE
Completion and creation dialogs, message component

### DIFF
--- a/apps/web-app/src/app/features/completion-warn-dialog/completion-dialog.css
+++ b/apps/web-app/src/app/features/completion-warn-dialog/completion-dialog.css
@@ -1,0 +1,21 @@
+mat-dialog-actions {
+  gap: 0.5rem;
+}
+
+mat-dialog-content {
+  display: flex;
+  gap: 1rem;
+  flex-direction: column;
+}
+
+app-message p {
+  text-align: justify;
+
+  &:first-of-type {
+    margin-block-start: 0;
+  }
+
+  &:last-of-type {
+    margin-block-end: 0;
+  }
+}

--- a/apps/web-app/src/app/features/completion-warn-dialog/completion-dialog.html
+++ b/apps/web-app/src/app/features/completion-warn-dialog/completion-dialog.html
@@ -1,0 +1,41 @@
+@if (!data.board.CompletionDateUtc) {
+<h2 mat-dialog-title>Finishing the game</h2>
+<mat-dialog-content>
+  <app-message [title]="'Reward'" [type]="'warning'">
+    <p>This is your last chance to change the reward.</p>
+  </app-message>
+
+  <app-deadline-reward-form
+    [createMode]="false"
+    [displayDeadline]="false"
+    [gameMode]="data.board.GameMode"></app-deadline-reward-form>
+</mat-dialog-content>
+<mat-dialog-actions>
+  <button matButton (click)="dialogRef.close()">Cancel</button>
+  <button mat-flat-button [mat-dialog-close]="'save'" cdkFocusInitial>Save</button>
+</mat-dialog-actions>
+} @else {
+<h2 mat-dialog-title>{{data.board.GameMode === 'traditional' ? 'BINGO!' : 'Well done!'}}</h2>
+<mat-dialog-content>
+  <app-message [title]="endStateMessage" [type]="'success'">
+    @if (data.board.GameMode === 'traditional') {
+    <p>Consider continuing the board in TO-DO mode to mark all cells as done</p>
+    }
+  </app-message>
+
+  @if (data.board.Visibility === 'local') {
+  <app-message [title]="'Local board'" [type]="'info'">
+    <p>This is a local board. You have to delete it if you want to start a new one.</p>
+  </app-message>
+  }
+</mat-dialog-content>
+<mat-dialog-actions>
+  <button matButton (click)="dialogRef.close()" cdkFocusInitial>Close</button>
+  @if (data.board.Visibility === 'local') {
+  <button mat-stroked-button [mat-dialog-close]="'delete'">Delete board</button>
+  } @if (data.board.GameMode === 'traditional') {
+  <button mat-flat-button [mat-dialog-close]="'continue'" cdkFocusInitial>Continue in TO-DO mode</button>
+
+  }
+</mat-dialog-actions>
+}

--- a/apps/web-app/src/app/features/completion-warn-dialog/completion-dialog.ts
+++ b/apps/web-app/src/app/features/completion-warn-dialog/completion-dialog.ts
@@ -1,0 +1,64 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  inject,
+} from '@angular/core';
+import {
+  MAT_DIALOG_DATA,
+  MatDialogRef,
+  MatDialogTitle,
+  MatDialogContent,
+  MatDialogActions,
+  MatDialogClose,
+} from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+import { Message } from '../message/message';
+import { DeadlineRewardForm } from '../deadline-reward-form/deadline-reward-form';
+import { BoardInfo } from '../board/board';
+
+@Component({
+  selector: 'app-completion-dialog',
+  imports: [
+    MatButtonModule,
+    MatDialogTitle,
+    MatDialogContent,
+    MatDialogActions,
+    MatDialogClose,
+    Message,
+    DeadlineRewardForm,
+  ],
+  templateUrl: './completion-dialog.html',
+  styleUrl: './completion-dialog.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class CompletionDialog {
+  readonly dialogRef = inject(MatDialogRef<CompletionDialog>);
+  readonly data = inject<{ board: BoardInfo }>(MAT_DIALOG_DATA);
+
+  public readonly endStateMessage = CompletionDialog.generateEndStateMessage(
+    this.data.board
+  );
+
+  private static generateEndStateMessage(board: BoardInfo, isOwnBoard = true) {
+    if (!board.CompletionDateUtc || !isOwnBoard) {
+      return '';
+    }
+
+    let message = 'You did it';
+
+    if (
+      !!board.CompletionDeadlineUtc &&
+      new Date(board.CompletionDateUtc) <= new Date(board.CompletionDeadlineUtc)
+    ) {
+      message += ' before the deadline!';
+    } else {
+      message += '!';
+    }
+
+    if (board.CompletionReward) {
+      message += ` You've earned ${board.CompletionReward}!`;
+    }
+
+    return message;
+  }
+}

--- a/apps/web-app/src/app/features/deadline-reward-form/deadline-reward-form.html
+++ b/apps/web-app/src/app/features/deadline-reward-form/deadline-reward-form.html
@@ -1,8 +1,11 @@
-@let minDate = minDate$ | async;
-@let canOnlyRemove = canOnlyRemove$() | async;
+@let minDate = minDate$ | async; @let canOnlyRemove = canOnlyRemove$() | async;
+
+<!-- DEADLINE -->
 
 <!-- prettier-ignore -->
-@if (deadlineInputsDisplay() === 'none'){
+@if (!displayDeadline()) {
+
+} @else if (deadlineInputsDisplay() === 'none'){
 <div class="horizontal">
   @if (!!gameModeForm().getRawValue().CompletionDeadlineUtc) {
   <span
@@ -13,6 +16,7 @@
     >
   </span>
 
+  <!-- prettier-ignore -->
   @let tooltip = 'Remove deadline (' + (gameMode() === 'todo' ? 'To-do' : 'Traditional') + ' game mode)';
   <button
     matIconButton
@@ -76,6 +80,8 @@
 </button>
 } }
 
+<!-- REWARD -->
+
 <!-- prettier-ignore -->
 @if (!canOnlyRemove) {
 <mat-form-field [subscriptSizing]="'dynamic'">
@@ -88,11 +94,9 @@
   <mat-hint>{{rewardHint}}</mat-hint>
   }
 </mat-form-field>
-}
-
+} @else {
 <!-- prettier-ignore -->
 @let reward = gameModeForm().getRawValue().CompletionReward;
-@if (canOnlyRemove) {
 @if (reward) {
 @let tooltip = 'Remove reward (' + (gameMode() === 'todo' ? 'To-do' : 'Traditional') + ' game mode)';
 <div class="horizontal">

--- a/apps/web-app/src/app/features/deadline-reward-form/deadline-reward-form.ts
+++ b/apps/web-app/src/app/features/deadline-reward-form/deadline-reward-form.ts
@@ -65,6 +65,7 @@ import { toObservable } from '@angular/core/rxjs-interop';
 export class DeadlineRewardForm implements OnInit, OnDestroy {
   public readonly createMode = input.required<boolean>();
   public readonly gameMode = input.required<'todo' | 'traditional'>();
+  public readonly displayDeadline = input<boolean>(true);
 
   private static readonly minDateMinutesFromNow = 15;
 

--- a/apps/web-app/src/app/features/message/message.css
+++ b/apps/web-app/src/app/features/message/message.css
@@ -1,0 +1,45 @@
+:host {
+  --warning: #ffa726;
+  --success: #66bb6a;
+  --info: #29b6f6;
+  --error: #f44336;
+  --color: white;
+
+  padding: 0.7rem;
+  display: grid;
+  grid-template-columns: 24px auto;
+  grid-template-rows: 24px auto;
+  grid-template-areas:
+    "icon title"
+    ". content";
+  gap: 0.3rem 0.4rem;
+  border-radius: var(--mat-sys-corner-medium);
+  background-color: light-dark(
+    hsl(from var(--color) h calc(s - 30) calc(l + 32.5)),
+    hsl(from var(--color) h calc(s - 30) calc(l - 50))
+  );
+  color: light-dark(
+    hsl(from var(--color) h s calc(l - 35)),
+    hsl(from var(--color) h s calc(l + 25))
+  );
+
+  &:has(div:empty) {
+    gap: 0 0.4rem;
+  }
+
+  mat-icon {
+    grid-area: icon;
+    --mat-icon-color: var(--color);
+  }
+
+  h3 {
+    font-weight: 500;
+    grid-area: title;
+    margin: 0;
+    align-content: center;
+  }
+
+  div {
+    grid-area: content;
+  }
+}

--- a/apps/web-app/src/app/features/message/message.html
+++ b/apps/web-app/src/app/features/message/message.html
@@ -1,0 +1,3 @@
+<mat-icon fontSet="material-symbols-outlined">{{icon()}}</mat-icon>
+<h3>{{title()}}</h3>
+<div><ng-content></ng-content></div>

--- a/apps/web-app/src/app/features/message/message.ts
+++ b/apps/web-app/src/app/features/message/message.ts
@@ -1,0 +1,35 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  input,
+} from '@angular/core';
+import { MatIcon } from '@angular/material/icon';
+
+@Component({
+  selector: 'app-message',
+  imports: [MatIcon],
+  templateUrl: './message.html',
+  styleUrl: './message.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    '[style.--color]': "'var(--' + type() + ')'",
+  },
+})
+export class Message {
+  public readonly type = input.required<
+    'success' | 'info' | 'warning' | 'error'
+  >();
+  public readonly title = input.required<string>();
+  public readonly icon = computed(
+    () =>
+      ((
+        {
+          success: 'check_circle',
+          info: 'info',
+          warning: 'warning',
+          error: 'error',
+        } as const
+      )[this.type()])
+  );
+}

--- a/apps/web-app/src/app/features/persistence/bingo-local.ts
+++ b/apps/web-app/src/app/features/persistence/bingo-local.ts
@@ -21,6 +21,15 @@ export class BingoLocalStorage {
     Visibility: 'local',
   });
 
+  public static boardInLocalStorage() {
+    const board = localStorage.getItem(BingoLocalStorage.LocalStorageBoardKey);
+    if (!board) {
+      return false;
+    } else {
+      return !!new BoardInfo(JSON.parse(board)).Cells.length;
+    }
+  }
+
   public static createBoard(
     board: BoardInfo<BoardCellDto>
   ): Observable<string> {
@@ -43,7 +52,7 @@ export class BingoLocalStorage {
     calculationService: BoardCalculations
   ): Observable<BoardInfo> {
     const board = localStorage.getItem(BingoLocalStorage.LocalStorageBoardKey);
-    if (!board) {
+    if (!BingoLocalStorage.boardInLocalStorage() || !board) {
       return of(new BoardInfo(BingoLocalStorage.DefaultBoard));
     } else {
       const parsedBoard = JSON.parse(board) as BoardInfo;
@@ -71,7 +80,7 @@ export class BingoLocalStorage {
   public static updateBoard(
     updatedBoard: BoardInfo,
     calculationService: BoardCalculations
-  ): Observable<void> {
+  ): Observable<boolean> {
     BoardCalculations.calculateCellBingoState(
       updatedBoard.Cells,
       calculationService
@@ -84,7 +93,7 @@ export class BingoLocalStorage {
       JSON.stringify(updatedBoard)
     );
 
-    return of();
+    return of(true);
   }
 
   private static calculateCompletionAndFirstBingoDates(board: BoardInfo) {

--- a/apps/web-app/src/app/features/save-warn-dialog/save-warn-dialog.css
+++ b/apps/web-app/src/app/features/save-warn-dialog/save-warn-dialog.css
@@ -1,0 +1,22 @@
+mat-dialog-content {
+  display: flex;
+  gap: 1rem;
+  flex-direction: column;
+
+  app-message p {
+    text-align: justify;
+
+    &:first-of-type {
+      margin-block-start: 0;
+    }
+
+    &:last-of-type {
+      margin-block-end: 0;
+    }
+  }
+
+  ul {
+    padding-inline-start: 0;
+    margin-block-start: 0;
+  }
+}

--- a/apps/web-app/src/app/features/save-warn-dialog/save-warn-dialog.html
+++ b/apps/web-app/src/app/features/save-warn-dialog/save-warn-dialog.html
@@ -1,0 +1,27 @@
+<h2 mat-dialog-title>Have you checked your cells?</h2>
+<mat-dialog-content>
+  <app-message [title]="'Beware'" [type]="'warning'">
+    <ul>
+      <li>Resizing the board</li>
+      <li>Reordering or changing the cells</li>
+      <li>Changing visibility from and to local</li>
+    </ul>
+    <p>is not possible once the game starts, so consider reviewing these before pressing Start</p>
+  </app-message>
+  <app-message [title]="'Editing'" [type]="'info'">
+    <p>You will be able to change anything else later.</p>
+  </app-message>
+
+  @if (data.overridesLocal) {
+  <app-message [title]="'Local board'" [type]="'warning'">
+    <p>
+      You are about to override your previous
+      <a href="./board/local" target="_blank">local board</a>.
+    </p></app-message
+  >
+  }
+</mat-dialog-content>
+<mat-dialog-actions>
+  <button matButton (click)="dialogRef.close()">Cancel</button>
+  <button mat-flat-button [mat-dialog-close]="''" cdkFocusInitial>Start game</button>
+</mat-dialog-actions>

--- a/apps/web-app/src/app/features/save-warn-dialog/save-warn-dialog.ts
+++ b/apps/web-app/src/app/features/save-warn-dialog/save-warn-dialog.ts
@@ -1,0 +1,33 @@
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import {
+  MatDialogTitle,
+  MatDialogContent,
+  MatDialogActions,
+  MatDialogClose,
+  MAT_DIALOG_DATA,
+  MatDialogRef,
+} from '@angular/material/dialog';
+import { Message } from '../message/message';
+import { BoardInfo } from '../board/board';
+
+@Component({
+  selector: 'app-save-warn-dialog',
+  imports: [
+    MatButtonModule,
+    MatDialogTitle,
+    MatDialogContent,
+    MatDialogActions,
+    MatDialogClose,
+    Message,
+  ],
+  templateUrl: './save-warn-dialog.html',
+  styleUrl: './save-warn-dialog.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class SaveWarnDialog {
+  readonly dialogRef = inject(MatDialogRef<SaveWarnDialog>);
+  readonly data = inject<{ board: BoardInfo; overridesLocal: boolean }>(
+    MAT_DIALOG_DATA
+  );
+}

--- a/apps/web-app/src/app/pages/board-page/board-page.css
+++ b/apps/web-app/src/app/pages/board-page/board-page.css
@@ -38,11 +38,8 @@
     flex-direction: column;
     gap: 1rem;
 
+    h3,
     h4 {
-      margin: 0;
-    }
-
-    h5 {
       margin: 0;
     }
 
@@ -76,6 +73,12 @@
     -webkit-box-orient: vertical;
     overflow: hidden;
     text-overflow: ellipsis;
+
+    .trophy {
+      height: 1rem;
+      width: 1rem;
+      font-size: 1rem;
+    }
   }
 
   .trophy {

--- a/apps/web-app/src/app/pages/board-page/board-page.html
+++ b/apps/web-app/src/app/pages/board-page/board-page.html
@@ -15,7 +15,17 @@
 @let totalCells = board().Cells.length;
 
 <div>
-  <h1>{{ board().Name || "Untitled Board" }}</h1>
+  <h1>
+    @if (goalReached()) {
+    <mat-icon
+      fontSet="material-symbols-outlined"
+      class="trophy"
+      [matTooltip]="'Goal reached on ' + (board().CompletionDateUtc | date : 'MMM dd, yyyy')"
+      >trophy</mat-icon
+    >
+    }
+    {{ board().Name || "Untitled Board" }}
+  </h1>
 
   <menu aria-label="Edit and save actions">
     @if (pendingSelectCount() !== 0) {
@@ -65,7 +75,7 @@
 
   <mat-divider></mat-divider>
 
-  <h4>Actions</h4>
+  <h3>Actions</h3>
   <mat-checkbox [(ngModel)]="doDelete" [disabled]="boardForm.controls.Name.disabled"
     >Delete board</mat-checkbox
   >
@@ -73,7 +83,7 @@
 
   @if(!!board().TraditionalGame.CompletionDateUtc && (!!board().TraditionalGame.CompletionReward ||
   !!board().TraditionalGame.CompletionDeadlineUtc)) {
-  <h5>Remove reward/deadline for completed traditional game</h5>
+  <h4>Remove reward/deadline for completed traditional game</h4>
   <app-deadline-reward-form [createMode]="false" [gameMode]="'traditional'">
   </app-deadline-reward-form>
   }
@@ -81,22 +91,12 @@
   <!-- prettier-ignore -->
   @if(!!board().TodoGame.CompletionDateUtc && (!!board().TodoGame.CompletionReward ||
   !!board().TodoGame.CompletionDeadlineUtc)) {
-  <h5>Remove reward/deadline for completed todo game</h5>
+  <h4>Remove reward/deadline for completed todo game</h4>
   <app-deadline-reward-form [createMode]="false" [gameMode]="'todo'"> </app-deadline-reward-form>
   }
 
   <mat-divider></mat-divider>
 </section>
-}
-
-<!-- prettier-ignore -->
-@if (goalReached()) {
-<div>
-  @if (board().GameMode === 'traditional') { {{endStateMessage()}}
-  <button matButton (click)="continueAfterBingo()">Continue in TODO mode</button>
-  } @else { {{endStateMessage()}} }
-</div>
-{{ isLocal() ? "This is a local board. You have to delete it to start a new one." : "" }}
 }
 
 <div class="board-container">

--- a/apps/web-app/src/app/pages/board-page/board-page.ts
+++ b/apps/web-app/src/app/pages/board-page/board-page.ts
@@ -7,7 +7,7 @@ import {
   model,
   signal,
 } from '@angular/core';
-import { Board, BoardInfo } from '../../features/board/board';
+import { Board, BoardCell, BoardInfo } from '../../features/board/board';
 import { MatButton, MatIconButton } from '@angular/material/button';
 import { BingoLocalStorage } from '../../features/persistence/bingo-local';
 import { Router } from '@angular/router';
@@ -25,6 +25,9 @@ import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { DeadlineRewardForm } from '../../features/deadline-reward-form/deadline-reward-form';
 import { BoardCalculations } from '../../features/calculations/board-calculations';
 import { DeadlineHourglass } from '../../features/deadline-hourglass/deadline-hourglass';
+import { MatDialog } from '@angular/material/dialog';
+import { CompletionDialog } from '../../features/completion-warn-dialog/completion-dialog';
+import { EMPTY, map, Observable, of, pipe, switchMap, tap } from 'rxjs';
 
 @Component({
   selector: 'app-board-page',
@@ -54,9 +57,10 @@ import { DeadlineHourglass } from '../../features/deadline-hourglass/deadline-ho
 })
 export class BoardPage {
   public readonly board = model.required<BoardInfo>();
-  private readonly calculationService = inject(BoardCalculations);
-  private readonly bingoApi = inject(BingoApi);
 
+  private readonly bingoApi = inject(BingoApi);
+  private readonly calculationService = inject(BoardCalculations);
+  private readonly dialog = inject(MatDialog);
   private readonly router = inject(Router);
 
   public readonly editMode = signal(false);
@@ -73,10 +77,6 @@ export class BoardPage {
 
   public readonly allChecked = computed(() =>
     this.cells().every((c) => c.IsInBingoPattern)
-  );
-
-  public readonly endStateMessage = computed(() =>
-    BoardPage.generateEndStateMessage(this.board())
   );
 
   public readonly goalReached = computed(
@@ -111,20 +111,6 @@ export class BoardPage {
     this.doDelete.set(false);
   }
 
-  public continueAfterBingo() {
-    const updatedBoard = new BoardInfo({
-      ...this.board(),
-      GameMode: 'todo' as const,
-    });
-
-    if (this.isLocal()) {
-      this.board.set(updatedBoard);
-      BingoLocalStorage.updateBoard(this.board(), this.calculationService);
-    } else {
-      // this.bingoApi.updateBoard(this.board().Id, updatedBoard).subscribe();
-    }
-  }
-
   public editBoard() {
     this.boardForm.reset();
     this.boardForm.enable();
@@ -133,6 +119,11 @@ export class BoardPage {
   }
 
   public saveChanges() {
+    if (this.doDelete()) {
+      this.deleteBoard();
+      return;
+    }
+    
     // see the constructor of BoardInfo about setting fields to null in case of game mode switch
     // not allowing to change certain fields is the responsibility of the components displaying the inputs
     const updatedBoard = new BoardInfo({
@@ -140,42 +131,60 @@ export class BoardPage {
       Cells: this.cells(),
     });
 
-    if (this.isLocal()) {
-      if (this.doDelete()) {
-        BingoLocalStorage.resetBoard();
-        this.router.navigate(['board/create']);
-      } else {
+    const isCompleting = BoardPage.isCompleteAfterSave(
+      updatedBoard,
+      updatedBoard.Cells,
+      this.calculationService
+    );
+
+    if (isCompleting) {
+      // when changing game mode from todo to traditional this can happen
+      this.saveCompletion(updatedBoard).pipe(this.afterCompletion).subscribe();
+    } else {
+      if (this.isLocal()) {
         BingoLocalStorage.updateBoard(updatedBoard, this.calculationService);
         this.board.set(updatedBoard);
-      }
-    } else {
-      if (this.doDelete()) {
-        // this.bingoApi.deleteBoard(this.board().Id).subscribe();
       } else {
         // this.bingoApi.updateBoard(this.board().Id, formData).subscribe();
       }
+      this.editMode.set(false);
     }
-    this.editMode.set(false);
   }
 
   public saveSelected() {
     const updatedBoard = new BoardInfo({
       ...this.board(),
-      Cells: this.cells().map((c) => {
+      Cells: this.cells().map((c, idx) => {
+        const cell = new BoardCell(
+          c,
+          idx,
+          BoardCalculations.getBoardDimensionFromCellCount(
+            this.cells().length
+          ) as number
+        );
         if (c.Selected) {
-          c.CheckedDateUTC = new Date();
-          c.Selected = false;
+          cell.CheckedDateUTC = new Date();
         }
 
-        return c;
+        return cell;
       }),
     });
 
-    if (this.isLocal()) {
-      BingoLocalStorage.updateBoard(updatedBoard, this.calculationService);
-      this.board.set(updatedBoard);
+    const isCompleting = BoardPage.isCompleteAfterSave(
+      this.board(),
+      updatedBoard.Cells,
+      this.calculationService
+    );
+
+    if (isCompleting) {
+      this.saveCompletion(updatedBoard).pipe(this.afterCompletion).subscribe();
     } else {
-      // this.bingoApi.updateBoard(this.board().Id, updatedBoard).subscribe();
+      if (this.isLocal()) {
+        BingoLocalStorage.updateBoard(updatedBoard, this.calculationService);
+        this.board.set(updatedBoard);
+      } else {
+        // this.bingoApi.updateBoard(this.board().Id, updatedBoard).subscribe();
+      }
     }
   }
 
@@ -191,26 +200,123 @@ export class BoardPage {
     );
   }
 
-  private static generateEndStateMessage(board: BoardInfo, isOwnBoard = true) {
-    if (!board.CompletionDateUtc || !isOwnBoard) {
-      return '';
-    }
+  private readonly afterCompletion = pipe(
+    switchMap((board: null | BoardInfo) => {
+      if (board === null) {
+        return EMPTY;
+      } else {
+        this.board.set(board);
 
-    let message = 'You did it';
+        const dialogRef = this.dialog.open(CompletionDialog, {
+          disableClose: true,
+          data: { board: board },
+        });
+
+        return dialogRef.afterClosed() as Observable<
+          undefined | 'continue' | 'delete'
+        >;
+      }
+    }),
+    switchMap((action) => {
+      switch (action) {
+        case 'continue':
+          return this.continueAfterBingo();
+        case 'delete':
+          return this.deleteBoard();
+        default:
+          return "Closed completion dialog";
+      }
+    })
+  );
+
+  private continueAfterBingo() {
+    const updatedBoard = new BoardInfo({
+      ...this.board(),
+      GameMode: 'todo' as const,
+    });
+
+    if (this.isLocal()) {
+      this.board.set(updatedBoard);
+      BingoLocalStorage.updateBoard(this.board(), this.calculationService);
+      return of("Successful continue after bingo update");
+    } else {
+      return of("Successful continue after bingo update");
+      // this.bingoApi.updateBoard(this.board().Id, updatedBoard).subscribe();
+    }
+  }
+
+  private deleteBoard() {
+    if (this.isLocal()) {
+      BingoLocalStorage.resetBoard();
+      this.router.navigate(['board/create']);
+      return of("Successful deletion");
+    } else {
+      return of("Successful deletion");
+      // this.bingoApi.deleteBoard(this.board().Id).subscribe();
+    }
+  }
+
+  private saveCompletion(board: BoardInfo) {
+    this.boardForm.reset();
+    this.boardForm.enable();
+    this.boardForm.patchValue(board);
+
+    const dialogRef = this.dialog.open(CompletionDialog, {
+      data: { board: board },
+    });
+
+    return dialogRef.afterClosed().pipe(
+      switchMap((result: undefined | string) => {
+        if (result !== undefined) {
+          const formValue = this.boardForm.getRawValue();
+          board.TodoGame.CompletionReward = formValue.TodoGame.CompletionReward;
+          board.TraditionalGame.CompletionReward =
+            formValue.TraditionalGame.CompletionReward;
+          board = new BoardInfo(board);
+
+          if (this.isLocal()) {
+            return BingoLocalStorage.updateBoard(
+              board,
+              this.calculationService
+            ).pipe(
+              tap((_) => {
+                this.boardForm.reset();
+                this.editMode.set(false);
+              }),
+              map((_) => board)
+            );
+          } else {
+            // this.bingoApi.updateBoard(this.board().Id, updatedBoard).subscribe();
+            return of(null); // should return board as well
+          }
+        }
+        return of(null);
+      })
+    );
+  }
+
+  private static isCompleteAfterSave(
+    board: BoardInfo,
+    cells: BoardCell[],
+    calculationService: BoardCalculations
+  ) {
+    const calculatedCells = BoardCalculations.calculateCellBingoState(
+      JSON.parse(JSON.stringify(cells)),
+      calculationService
+    );
 
     if (
-      !!board.CompletionDeadlineUtc &&
-      new Date(board.CompletionDateUtc) <= new Date(board.CompletionDeadlineUtc)
+      !!board.TodoGame.CompletionDateUtc ||
+      (board.GameMode === 'traditional' &&
+        !!board.TraditionalGame.CompletionDateUtc)
     ) {
-      message += ' before the deadline!';
-    } else {
-      message += '!';
+      return false;
     }
 
-    if (board.CompletionReward) {
-      message += ` You've earned ${board.CompletionReward}!`;
-    }
-
-    return message;
+    return (
+      (board.GameMode === 'traditional' &&
+        !!calculatedCells.find((c) => c.IsInBingoPattern)) ||
+      !calculatedCells.find((c) => !c.IsInBingoPattern)
+    );
   }
 }

--- a/apps/web-app/src/app/pages/board-setup-page/board-setup.ts
+++ b/apps/web-app/src/app/pages/board-setup-page/board-setup.ts
@@ -44,10 +44,14 @@ import { BoardListView } from '../../features/board-list-view/board-list-view';
 import { MatDivider } from '@angular/material/divider';
 import { BoardCalculations } from '../../features/calculations/board-calculations';
 import { DeadlineRewardForm } from '../../features/deadline-reward-form/deadline-reward-form';
+import { SaveWarnDialog } from '../../features/save-warn-dialog/save-warn-dialog';
+import { MatDialog } from '@angular/material/dialog';
 
 type CellForm = FormGroup<{
   Name: FormControl<string | null>;
   Selected: FormControl<boolean>;
+  Row: FormControl<number>;
+  Column: FormControl<number>;
 }>;
 
 @Component({
@@ -84,6 +88,7 @@ type CellForm = FormGroup<{
   },
 })
 export class BoardSetup implements OnInit {
+  private readonly dialog = inject(MatDialog);
   private readonly router = inject(Router);
   private readonly bingoApi = inject(BingoApi);
 
@@ -97,10 +102,16 @@ export class BoardSetup implements OnInit {
   public isLoggedIn = false;
 
   public readonly cardsFormArray = new FormArray<CellForm>(
-    [...Array(this.defaultBoardSize).keys()].map((_) => {
+    [...Array(this.defaultBoardSize).keys()].map((_, index) => {
       return new FormGroup({
         Name: new FormControl<string | null>(null, [Validators.required]),
         Selected: new FormControl<boolean>(false, { nonNullable: true }),
+        Row: new FormControl<number>(Math.floor(index / this.boardSize) + 1, {
+          nonNullable: true,
+        }),
+        Column: new FormControl<number>((index % this.boardSize) + 1, {
+          nonNullable: true,
+        }),
       });
     })
   );
@@ -142,12 +153,23 @@ export class BoardSetup implements OnInit {
       ),
     });
 
-    if (board.Visibility === 'local') {
-      BingoLocalStorage.createBoard(board);
-      this.router.navigate(['board/local']);
-    } else {
-      // this.bingoApi.createBoard(board).subscribe();
-    }
+    const dialogRef = this.dialog.open(SaveWarnDialog, {
+      data: {
+        board: board,
+        overridesLocal: BingoLocalStorage.boardInLocalStorage(),
+      },
+    });
+
+    dialogRef.afterClosed().subscribe((result) => {
+      if (result !== undefined) {
+        if (board.Visibility === 'local') {
+          BingoLocalStorage.createBoard(board);
+          this.router.navigate(['board/local']);
+        } else {
+          // this.bingoApi.createBoard(board).subscribe();
+        }
+      }
+    });
   }
 
   public indicateFocused(
@@ -191,6 +213,12 @@ export class BoardSetup implements OnInit {
             [Validators.required, Validators.pattern(NotOnlyWhiteSpacePattern)]
           ),
           Selected: new FormControl<boolean>(false, { nonNullable: true }),
+          Row: new FormControl<number>(Math.floor(idx / dimension) + 1, {
+            nonNullable: true,
+          }),
+          Column: new FormControl<number>((idx % dimension) + 1, {
+            nonNullable: true,
+          }),
         })
       );
     });

--- a/apps/web-app/src/styles.scss
+++ b/apps/web-app/src/styles.scss
@@ -44,6 +44,13 @@ body {
   // &.dark-mode {
   //   color-scheme: dark;
   // }
+
+  @include mat.dialog-overrides(
+    (
+      container-color:
+        light-dark(var(--mat-sys-surface), var(--mat-sys-surface-container-low)),
+    )
+  );
 }
 
 mat-stepper.no-space-on-last-step {


### PR DESCRIPTION
Added a message component inspired by [the mui implementation](https://mui.com/material-ui/react-alert/)

During creation a dialog warns the user to check settings that can't be changed later.
During completion a dialog offers to change the reward before it gets locked, then after a successful save another one comes up to congratulate them, also offering quick actions like deleting a local board or continuing in TO-DO mode.
The same dialogs come up if the user changes the game mode from todo to traditional and bingo was already reached.

Fixed the missing "Row , Column " labels on the board-setup page in list view.

Related code refactors and some style changes included as well.