### PR TITLE
Can create a copy of the board

### DIFF
--- a/apps/web-app/src/app/app.routes.ts
+++ b/apps/web-app/src/app/app.routes.ts
@@ -2,6 +2,7 @@ import { Routes } from '@angular/router';
 import { ProfilePage } from './features/init/profile-page/profile-page';
 import { MsalGuard } from '@azure/msal-angular';
 import { boardResolver } from './pages/board-page/board-resolver';
+import { boardToCopyResolver } from './pages/board-setup-page/board-resolver';
 
 export const routes: Routes = [
   // {
@@ -13,6 +14,14 @@ export const routes: Routes = [
     path: 'board/create',
     loadComponent: () =>
       import('./pages/board-setup-page/board-setup').then((m) => m.BoardSetup),
+  },
+  {
+    path: 'board/copy/local',
+    loadComponent: () =>
+      import('./pages/board-setup-page/board-setup').then((m) => m.BoardSetup),
+    resolve: {
+      board: boardToCopyResolver,
+    },
   },
   {
     path: 'board/local',

--- a/apps/web-app/src/app/features/completion-warn-dialog/completion-dialog.css
+++ b/apps/web-app/src/app/features/completion-warn-dialog/completion-dialog.css
@@ -18,6 +18,10 @@ app-message p {
   &:last-of-type {
     margin-block-end: 0;
   }
+
+  a {
+    text-decoration: underline;
+  }
 }
 
 mat-checkbox {

--- a/apps/web-app/src/app/features/completion-warn-dialog/completion-dialog.html
+++ b/apps/web-app/src/app/features/completion-warn-dialog/completion-dialog.html
@@ -26,6 +26,7 @@
   @if (data.board.Visibility === 'local') {
   <app-message [title]="'Local board'" [type]="'info'">
     <p>This is a local board. You have to delete it if you want to start a new one.</p>
+    <p>Alternatively you can <a href="/board/copy/local">Create a copy of it</a></p>
     <mat-checkbox [(ngModel)]="deleteBoard">Delete board</mat-checkbox>
   </app-message>
   }

--- a/apps/web-app/src/app/features/confirm-dialog/confirm-dialog.html
+++ b/apps/web-app/src/app/features/confirm-dialog/confirm-dialog.html
@@ -1,0 +1,6 @@
+<h2 mat-dialog-title>Are you sure?</h2>
+
+<mat-dialog-actions>
+  <button matButton [mat-dialog-close]="false">No</button>
+  <button mat-flat-button [mat-dialog-close]="true">Yes</button>
+</mat-dialog-actions>

--- a/apps/web-app/src/app/features/confirm-dialog/confirm-dialog.spec.ts
+++ b/apps/web-app/src/app/features/confirm-dialog/confirm-dialog.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ConfirmDialog } from './confirm-dialog';
+import { provideZonelessChangeDetection } from '@angular/core';
+
+describe('ConfirmDialog', () => {
+  let component: ConfirmDialog;
+  let fixture: ComponentFixture<ConfirmDialog>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ConfirmDialog],
+      providers: [provideZonelessChangeDetection()],
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(ConfirmDialog);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/apps/web-app/src/app/features/confirm-dialog/confirm-dialog.ts
+++ b/apps/web-app/src/app/features/confirm-dialog/confirm-dialog.ts
@@ -1,0 +1,16 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import {
+  MatDialogTitle,
+  MatDialogActions,
+  MatDialogClose,
+} from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+
+@Component({
+  selector: 'app-confirm-dialog',
+  imports: [MatDialogTitle, MatDialogClose, MatDialogActions, MatButtonModule],
+  templateUrl: './confirm-dialog.html',
+  styleUrl: './confirm-dialog.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ConfirmDialog {}

--- a/apps/web-app/src/app/features/deadline-reward-form/deadline-reward-form.html
+++ b/apps/web-app/src/app/features/deadline-reward-form/deadline-reward-form.html
@@ -10,9 +10,11 @@
   @if (!!gameModeForm().getRawValue().CompletionDeadlineUtc) {
   <span
     >Deadline:
-    <span
+    <time
+      [attr.datetime]="gameModeForm().getRawValue().CompletionDeadlineUtc"
       class="gray"
-      >{{gameModeForm().getRawValue().CompletionDeadlineUtc | date : 'MMM dd, yyyy HH:mm'}}</span
+      >{{(gameModeForm().getRawValue().CompletionDeadlineUtc 
+      | intlDate : {dateStyle: 'medium', timeStyle: 'short', hour12: false})}}</time
     >
   </span>
 

--- a/apps/web-app/src/app/features/deadline-reward-form/deadline-reward-form.ts
+++ b/apps/web-app/src/app/features/deadline-reward-form/deadline-reward-form.ts
@@ -23,7 +23,7 @@ import {
   boardForm,
   NotOnlyWhiteSpacePattern,
 } from '../board-details-form/form';
-import { AsyncPipe, DatePipe } from '@angular/common';
+import { AsyncPipe } from '@angular/common';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatDatepickerModule } from '@angular/material/datepicker';
 import { MatFormFieldModule } from '@angular/material/form-field';
@@ -36,6 +36,7 @@ import { calculateDateFromNow } from '../calculations/date-calculations';
 import { provideNativeDateAdapter } from '@angular/material/core';
 import { DATE_FORMATS } from '../../app.config';
 import { toObservable } from '@angular/core/rxjs-interop';
+import { IntlDatePipe } from 'angular-ecmascript-intl';
 
 @Component({
   selector: 'app-deadline-reward-form',
@@ -46,7 +47,7 @@ import { toObservable } from '@angular/core/rxjs-interop';
     ReactiveFormsModule,
     MatDatepickerModule,
     MatTimepickerModule,
-    DatePipe,
+    IntlDatePipe,
     AsyncPipe,
     MatIcon,
     MatIconButton,
@@ -125,7 +126,7 @@ export class DeadlineRewardForm implements OnInit, OnDestroy {
             (this.gameMode() === 'traditional'
               ? this.boardForm.controls.TodoGame
               : this.boardForm.controls.TraditionalGame
-            ).patchValue(value, {emitEvent: false});
+            ).patchValue(value, { emitEvent: false });
           })
         );
       })
@@ -187,7 +188,9 @@ export class DeadlineRewardForm implements OnInit, OnDestroy {
 
     this.minDateSubscription = combineLatest([
       this.minDate$,
-      this.gameModeForm().controls.CompletionDeadlineUtc.valueChanges,
+      this.gameModeForm().controls.CompletionDeadlineUtc.valueChanges.pipe(
+        startWith(this.gameModeForm().getRawValue().CompletionDeadlineUtc)
+      ),
     ])
       .pipe(
         tap(([_, currentDate]) => {

--- a/apps/web-app/src/app/features/persistence/bingo-local.ts
+++ b/apps/web-app/src/app/features/persistence/bingo-local.ts
@@ -35,12 +35,18 @@ export class BingoLocalStorage {
     board: BoardInfo<BoardCellDto>
   ): Observable<string> {
     board.CreatedAtUtc = new Date();
+
+    // in normal cases there's no need for this
+    // but during copying we want to guarantee that these are set to their defaults
+    board.Id = undefined;
+    board.CreatedBy = 'local user';
+    board.LastChangedAtUtc = board.CreatedAtUtc;
     board.SwitchedToTodoAfterCompleteDateUtc = undefined;
     board.TraditionalGame.CompletedAtUtc = null;
     board.TraditionalGame.CompletedByGameModeSwitch = undefined;
     board.TodoGame.CompletedAtUtc = null;
     board.Cells.forEach(c => c.CheckedDateUTC = null);
-    
+
     localStorage.setItem(
       BingoLocalStorage.LocalStorageBoardKey,
       JSON.stringify(board)

--- a/apps/web-app/src/app/features/persistence/bingo-local.ts
+++ b/apps/web-app/src/app/features/persistence/bingo-local.ts
@@ -35,6 +35,12 @@ export class BingoLocalStorage {
     board: BoardInfo<BoardCellDto>
   ): Observable<string> {
     board.CreatedAtUtc = new Date();
+    board.SwitchedToTodoAfterCompleteDateUtc = undefined;
+    board.TraditionalGame.CompletedAtUtc = null;
+    board.TraditionalGame.CompletedByGameModeSwitch = undefined;
+    board.TodoGame.CompletedAtUtc = null;
+    board.Cells.forEach(c => c.CheckedDateUTC = null);
+    
     localStorage.setItem(
       BingoLocalStorage.LocalStorageBoardKey,
       JSON.stringify(board)

--- a/apps/web-app/src/app/pages/board-page/board-page.css
+++ b/apps/web-app/src/app/pages/board-page/board-page.css
@@ -28,7 +28,8 @@
 
   div,
   section,
-  menu {
+  menu,
+  mat-card {
     display: flex;
     align-items: center;
   }
@@ -37,6 +38,10 @@
     margin: 0;
     padding: 0;
     flex-shrink: 0;
+    margin-left: auto;
+  }
+
+  button.mat-mdc-menu-trigger {
     margin-left: auto;
   }
 
@@ -49,6 +54,17 @@
     h3,
     h4 {
       margin: 0;
+    }
+
+    mat-card {
+      margin: auto;
+      width: 100%;
+      padding: 0.5rem;
+      gap: 1rem;
+
+      h4 {
+        text-align: center;
+      }
     }
 
     mat-divider {

--- a/apps/web-app/src/app/pages/board-page/board-page.html
+++ b/apps/web-app/src/app/pages/board-page/board-page.html
@@ -6,7 +6,6 @@
     visible_public: "Public board, visible to those who visit your profile.",
     game_mode_bingo: "Bingo game mode with the goal of reaching a vertical, horizontal or diagonal pattern from marked tasks.",
     game_mode_todo: "TO-DO game mode with the goal of marking all tasks.",
-    edit_button: "Edit the board name, game mode, deadline or delete it.", 
 };
 @let switchTo = gridMode() === 'grid' ? 'list' : 'grid';
 @let buttonLabel = 'Switch to ' + switchTo + ' view';
@@ -25,6 +24,25 @@
     {{ board().Name || "Untitled Board" }}
   </h1>
 
+  @if (displayMode() !== 'edit' && displayMode() !== 'history' && pendingSelectCount() === 0) {
+  <button matIconButton [matMenuTriggerFor]="menu" aria-label="Available actions">
+    <mat-icon>more_vert</mat-icon>
+  </button>
+  <mat-menu #menu="matMenu">
+    <button mat-menu-item (click)="editBoard()">
+      <mat-icon>edit</mat-icon>
+      Edit
+    </button>
+    <a mat-menu-item routerLink="/board/copy/local">
+      <mat-icon>content_copy</mat-icon>
+      Copy
+    </a>
+    <button mat-menu-item (click)="deleteBoardClick()">
+      <mat-icon>delete</mat-icon>
+      Delete
+    </button>
+  </mat-menu>
+  } @else {
   <menu aria-label="Edit and save actions">
     @if (pendingSelectCount() !== 0) {
     <button mat-button (click)="unselect()">
@@ -35,28 +53,18 @@
       Save ({{ pendingSelectCount() }})
       <span class="cdk-visually-hidden">selected tasks as done</span>
     </button>
-    } @else if (displayMode() !== 'edit' && displayMode() !== 'history') {
-    <button
-      matIconButton
-      (click)="editBoard()"
-      attr.aria-label="{{ tooltips['edit_button'] }}"
-      [matTooltip]="tooltips['edit_button']">
-      <mat-icon>edit</mat-icon>
-    </button>
     } @else if (displayMode() === 'history') {
     <button mat-button (click)="displayMode.set('board')">Close history</button>
-    }@else {
+    } @else if (displayMode() === 'edit') {
     <button mat-button (click)="cancelChanges()">
       Cancel<span class="cdk-visually-hidden"> changes</span>
     </button>
     <button mat-flat-button (click)="saveChanges()" [disabled]="boardForm.controls.Name.disabled">
-      {{doDelete() ? 'Delete' : 'Save'}}
-      @if(doDelete()) {
-      <span class="cdk-visually-hidden"> board</span>
-      }
+      Save
     </button>
     }
   </menu>
+  }
 </div>
 
 @if (displayMode() === 'edit') {
@@ -74,29 +82,35 @@
   </app-deadline-reward-form>
   }
 
-  <mat-divider></mat-divider>
-
-  <h3>Actions</h3>
-  <mat-checkbox [(ngModel)]="doDelete" [disabled]="boardForm.controls.Name.disabled"
-    >Delete board</mat-checkbox
-  >
-  <button matButton disabled>Create copy</button>
-
-  @if(!!board().TraditionalGame.CompletedAtUtc && (!!board().TraditionalGame.CompletionReward ||
-  !!board().TraditionalGame.CompletionDeadlineUtc)) {
-  <h4>Remove reward/deadline for completed traditional game</h4>
-  <app-deadline-reward-form [createMode]="false" [gameMode]="'traditional'">
-  </app-deadline-reward-form>
-  }
+  <!-- prettier-ignore -->
+  @let hasRewardOrDeadlineTraditional = !!board().TraditionalGame.CompletedAtUtc &&
+  (!!board().TraditionalGame.CompletionReward || !!board().TraditionalGame.CompletionDeadlineUtc);
+  @let hasRewardOrDeadlineTodo = !!board().TodoGame.CompletedAtUtc &&
+  (!!board().TodoGame.CompletionReward || !!board().TodoGame.CompletionDeadlineUtc);
 
   <!-- prettier-ignore -->
-  @if(!!board().TodoGame.CompletedAtUtc && (!!board().TodoGame.CompletionReward ||
-  !!board().TodoGame.CompletionDeadlineUtc)) {
-  <h4>Remove reward/deadline for completed todo game</h4>
-  <app-deadline-reward-form [createMode]="false" [gameMode]="'todo'"> </app-deadline-reward-form>
-  }
+  @if (hasRewardOrDeadlineTraditional || hasRewardOrDeadlineTodo) {
+  <mat-card [appearance]="'outlined'">
+    <h4>Remove reward/deadline</h4>
+    @if(hasRewardOrDeadlineTraditional) {
+    <span>For completed game: traditional</span>
+    <app-deadline-reward-form [createMode]="false" [gameMode]="'traditional'">
+    </app-deadline-reward-form>
+    }
 
-  <mat-divider></mat-divider>
+    <!-- prettier-ignore -->
+    @if (hasRewardOrDeadlineTraditional && hasRewardOrDeadlineTodo) {
+    <mat-divider></mat-divider>
+    }
+
+    <!-- prettier-ignore -->
+    @if(hasRewardOrDeadlineTodo) {
+    <span>For completed game: to-do</span>
+    <app-deadline-reward-form [createMode]="false" [gameMode]="'todo'"> </app-deadline-reward-form>
+    }
+  </mat-card>
+
+  }
 </section>
 }
 

--- a/apps/web-app/src/app/pages/board-setup-page/board-resolver.spec.ts
+++ b/apps/web-app/src/app/pages/board-setup-page/board-resolver.spec.ts
@@ -1,0 +1,23 @@
+import { TestBed } from '@angular/core/testing';
+import { ResolveFn } from '@angular/router';
+
+import { boardToCopyResolver } from './board-resolver';
+import { Observable } from 'rxjs';
+import { BoardInfo } from '../../features/board/board';
+
+describe('boardToCopyResolver', () => {
+  const executeResolver: ResolveFn<Observable<BoardInfo>> = (
+    ...resolverParameters
+  ) =>
+    TestBed.runInInjectionContext(() =>
+      boardToCopyResolver(...resolverParameters)
+    );
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+  });
+
+  it('should be created', () => {
+    expect(executeResolver).toBeTruthy();
+  });
+});

--- a/apps/web-app/src/app/pages/board-setup-page/board-resolver.ts
+++ b/apps/web-app/src/app/pages/board-setup-page/board-resolver.ts
@@ -1,0 +1,29 @@
+import { ResolveFn, Router } from '@angular/router';
+import { inject } from '@angular/core';
+import { of, EMPTY, switchMap, Observable } from 'rxjs';
+import { BingoLocalStorage } from '../../features/persistence/bingo-local';
+import { BoardCalculations } from '../../features/calculations/board-calculations';
+import { BoardInfo } from '../../features/board/board';
+
+export const boardToCopyResolver: ResolveFn<Observable<BoardInfo>> = (route, state) => {
+  const router = inject(Router);
+  // const boardId = route.paramMap.get('id');
+
+  if (state.url.endsWith('board/copy/local')) {
+    const calculationService = inject(BoardCalculations);
+    
+    return BingoLocalStorage.loadBoard(calculationService).pipe(
+      switchMap((board) => {
+        if (board.Cells.length !== 0) {
+          return of(board);
+        } else {
+          router.navigate(['board/create']);
+          return EMPTY;
+        }
+      }),
+    );
+  }
+
+  router.navigate(['board/create']);
+  return EMPTY;
+};

--- a/apps/web-app/src/app/pages/board-setup-page/board-setup.ts
+++ b/apps/web-app/src/app/pages/board-setup-page/board-setup.ts
@@ -131,7 +131,14 @@ export class BoardSetup implements OnInit {
   );
 
   ngOnInit(): void {
-    const baseBoard = this.board() ?? this.baseBoard;
+    const board = this.board();
+    if (board) {
+      // makes reward and deadline belonging to another game mode be cleared in the BoardInfo constructor
+      board.TraditionalGame.CompletedAtUtc = board.TodoGame.CompletedAtUtc =
+        null;
+    }
+    const baseBoard = board ? new BoardInfo(board) : this.baseBoard;
+
     this.boardForm.reset();
     this.boardForm.enable();
     this.boardForm.patchValue(baseBoard);

--- a/apps/web-app/src/app/pages/board-setup-page/board-setup.ts
+++ b/apps/web-app/src/app/pages/board-setup-page/board-setup.ts
@@ -3,6 +3,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   inject,
+  input,
   OnInit,
   signal,
 } from '@angular/core';
@@ -88,11 +89,12 @@ type CellForm = FormGroup<{
   },
 })
 export class BoardSetup implements OnInit {
+  public readonly board = input<BoardInfo | null>(null);
   private readonly dialog = inject(MatDialog);
   private readonly router = inject(Router);
   private readonly bingoApi = inject(BingoApi);
 
-  public readonly baseBoard = new BoardInfo(BingoLocalStorage.DefaultBoard); // once copying boards is implemented, this should be dynamic
+  public readonly baseBoard = new BoardInfo(BingoLocalStorage.DefaultBoard);
   public readonly boardForm = boardForm;
   public readonly Math = Math;
   public readonly defaultBoardSize = 9;
@@ -122,21 +124,20 @@ export class BoardSetup implements OnInit {
       () =>
         this.cardsFormArray.getRawValue().map((c, idx) => ({
           IsInBingoPattern:
-            !!c.Name?.length && this.cardsFormArray.at(idx).valid,
+            !!c.Name?.toString()?.length && this.cardsFormArray.at(idx).valid,
           ...c,
         })) as BoardCell[]
     )
   );
 
   ngOnInit(): void {
+    const baseBoard = this.board() ?? this.baseBoard;
     this.boardForm.reset();
     this.boardForm.enable();
-    this.boardForm.patchValue(this.baseBoard);
+    this.boardForm.patchValue(baseBoard);
 
-    this.resizeBoard(
-      (this.baseBoard.Cells.length as any) || this.defaultBoardSize
-    );
-    this.cardsFormArray.patchValue(this.baseBoard.Cells);
+    this.resizeBoard((baseBoard.Cells.length as any) || this.defaultBoardSize);
+    this.cardsFormArray.patchValue(baseBoard.Cells);
   }
 
   public createBoard() {


### PR DESCRIPTION
Delete and copy buttons are now outside of the edit mode of the board page (because otherwise the user might think that if they modify the form, those changes would be copied as well) + non-owners should be able to copy public boards, and now its placement is consistent for owners and non-owners.

Copying board is implemented